### PR TITLE
Handle EOF

### DIFF
--- a/src/Console.elm
+++ b/src/Console.elm
@@ -1,6 +1,6 @@
 module Console (putChar, putStr, putStrLn, getChar, getLine, readUntil, writeFile,
            exit, map, mapIO, forEach, pure, apply, (<*>), andThen, (>>=),
-           seq, (>>>), forever, IO, run) where
+           seq, (>>>), forever, IO, run, getContents) where
 
 {-|
 
@@ -17,7 +17,7 @@ how to run such a computation.
 @docs putChar, putStr, putStrLn
 
 # Stdin
-@docs getChar, getLine, readUntil
+@docs getChar, getLine, getContents, readUntil
 
 # File Operations
 @docs writeFile
@@ -61,15 +61,19 @@ readUntil = Core.readUntil
 
 {-| Write content to a file -}
 writeFile : { file : String, content : String } -> Core.IO ()
-writeFile = Core.writeFile 
+writeFile = Core.writeFile
 
 {-| Read a line from stdin -}
 getLine : Core.IO String
 getLine = Core.getLine
 
+{-| Read from stdin until EOF -}
+getContents : Core.IO String
+getContents = Core.getContents
+
 {-| Apply a pure function to an IO value -}
 map : (a -> b) -> Core.IO a -> Core.IO b
-map = Core.map 
+map = Core.map
 
 {-| Alternative interface to forEach  -}
 mapIO : (a -> Core.IO ()) -> List a -> Core.IO ()
@@ -77,7 +81,7 @@ mapIO = Core.mapIO
 
 {-| Run an IO computation for each element of a list -}
 forEach : List a -> (a -> Core.IO ()) -> Core.IO ()
-forEach = Core.forEach 
+forEach = Core.forEach
 
 {-| Use a pure value where an IO computation is expected. -}
 pure : a -> Core.IO a

--- a/src/Console/Core.elm
+++ b/src/Console/Core.elm
@@ -39,6 +39,11 @@ writeFile obj = Impure (WriteF obj (\_ -> Pure ()))
 getLine : IO String
 getLine = readUntil '\n'
 
+
+{-| Read all stdin into a single string. -}
+getContents : IO String
+getContents = readUntil '\0'
+
 -- | IO Combinators
 
 {-| Apply a pure function to an IO value -}

--- a/src/Console/NativeCom.elm
+++ b/src/Console/NativeCom.elm
@@ -2,15 +2,10 @@ module Console.NativeCom where
 
 import Task exposing (Task)
 
+import Console.NativeTypes exposing (IResponse, IRequest)
+
 import Native.Console.NativeCom
 
-type IRequest = Put String
-              | Exit Int
-              | Get
-              | WriteFile { file : String, content : String }
-              | Init
-
-type alias IResponse = Maybe String
 
 sendRequests : Signal (List IRequest) -> Signal (Task x ())
 sendRequests requests =

--- a/src/Console/NativeTypes.elm
+++ b/src/Console/NativeTypes.elm
@@ -1,0 +1,13 @@
+module Console.NativeTypes where
+
+type IRequest
+  = Init
+  | Get
+  | Put String
+  | WriteFile { file : String, content : String }
+  | Exit Int
+
+type IResponse
+  = Empty
+  | Data String
+  | EOF

--- a/test/Stdin.elm
+++ b/test/Stdin.elm
@@ -1,0 +1,9 @@
+module Main where
+
+import Console exposing ((>>=), putStr, getContents)
+import String
+import Task
+
+
+port runner : Signal (Task.Task x ())
+port runner = Console.run (getContents >>= putStr)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -ev
 
 cd "$(dirname "$0")"
 
@@ -29,6 +29,9 @@ cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 EOF`
 RESULT=`echo "$INPUT" | node build/test4.js`
-test "$INPUT" = "$RESULT"
+if [ ! "$INPUT" = "$RESULT" ]; then
+    echo "Unexpected output: $RESULT"
+    exit 1
+fi
 
 echo "Success"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -17,4 +17,18 @@ node build/test2.js
 elm-make --yes --output build/test3.js BigString.elm
 echo "Elm.worker(Elm.Main);" >> build/test3.js
 node build/test3.js > /dev/null
+
+elm-make --yes --output build/test4.js Stdin.elm
+echo "Elm.worker(Elm.Main);" >> build/test4.js
+INPUT=`cat <<EOF
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+EOF`
+RESULT=`echo "$INPUT" | node build/test4.js`
+test "$INPUT" = "$RESULT"
+
 echo "Success"


### PR DESCRIPTION
Before: EOF is not handled at all. In particular, `process.stdin.resume` is sometimes called on the closed stdin stream, and in that case node.js terminates without an error.

_This is a proposal._ The handling of EOF in this pull is a little bit hacky. The `getC` request to the native module returns `'\0'` if stdin is in EOF state. Better would be a proper error handling and isEof function. Right now, I have no idea how to do it. Feel free to make it better.

API changes:
- add `getContents` function incl. a test
