### PR TITLE
Add check to determine if in browser or node

### DIFF
--- a/src/Native/Console/NativeCom.js
+++ b/src/Native/Console/NativeCom.js
@@ -17,12 +17,11 @@ Elm.Native.Console.NativeCom.make = function(localRuntime) {
     var Utils = Elm.Native.Utils.make(localRuntime);
 
     /* Node.js imports */
-    try {
+    var inNode = typeof module !== 'undefined' && module.exports;
+    
+    if (inNode) {
         var fs = require('fs');
         var stdin = process.stdin;
-        var inNode = true;
-    } catch (reference_error) {
-        var inNode = false;
     }
 
     var sendResponseString = function(str) {

--- a/src/Native/Console/NativeCom.js
+++ b/src/Native/Console/NativeCom.js
@@ -20,9 +20,9 @@ Elm.Native.Console.NativeCom.make = function(localRuntime) {
     try {
         var fs = require('fs');
         var stdin = process.stdin;
-        var in_node = true;
+        var inNode = true;
     } catch (reference_error) {
-        var in_node = false;
+        var inNode = false;
     }
 
     var sendResponseString = function(str) {
@@ -37,7 +37,7 @@ Elm.Native.Console.NativeCom.make = function(localRuntime) {
 
     var responsesSignal = NS.input('Console.NativeCom.responses', Maybe.Nothing);
     
-    if (in_node) {
+    if (inNode) {
         stdin.on('data', function(chunk) {
             stdin.pause();
             sendResponseString(chunk.toString());
@@ -66,7 +66,7 @@ Elm.Native.Console.NativeCom.make = function(localRuntime) {
     }
 
     var doRequest = function(request) {
-        if (in_node) {
+        if (inNode) {
             switch(request.ctor) {
                 case 'Put':
                     process.stdout.write(request._0);


### PR DESCRIPTION
When I simplified the public API for `elm-test`, it caused a runtime error in the browser since the node-specific code here runs and crashes: https://github.com/deadfoxygrandpa/elm-test/issues/32

I've added some runtime checks to disable those things if it's run in the browser.
