### PR TITLE
Add map2 and sequence

### DIFF
--- a/src/Console.elm
+++ b/src/Console.elm
@@ -1,6 +1,6 @@
 module Console (putChar, putStr, putStrLn, getChar, getLine, readUntil, writeFile,
-           exit, map, mapIO, forEach, pure, apply, (<*>), andThen, (>>=),
-           seq, (>>>), forever, IO, run) where
+           exit, map, map2, mapIO, forEach, pure, apply, (<*>), andThen, (>>=),
+           seq, sequence, (>>>), forever, IO, run) where
 
 {-|
 
@@ -26,8 +26,8 @@ how to run such a computation.
 @docs exit
 
 # Plumbing
-@docs map, mapIO, forEach, pure, apply,
-      (<*>), andThen, (>>=), seq, (>>>), forever
+@docs map, map2, mapIO, forEach, pure, apply,
+      (<*>), andThen, (>>=), seq, sequence, (>>>), forever
 -}
 
 import Console.Core as Core
@@ -71,6 +71,10 @@ getLine = Core.getLine
 map : (a -> b) -> Core.IO a -> Core.IO b
 map = Core.map 
 
+{-| Apply a pure function to two IO values -}
+map2 : (a -> b -> result) -> IO a -> IO b -> IO result
+map2 = Core.map2
+
 {-| Alternative interface to forEach  -}
 mapIO : (a -> Core.IO ()) -> List a -> Core.IO ()
 mapIO = Core.mapIO
@@ -102,6 +106,10 @@ andThen = Core.andThen
 {-| Run one computation and then another, ignoring the first's output -}
 seq : Core.IO a -> Core.IO b -> Core.IO b
 seq = Core.seq
+
+{-| Run several computations in a sequence, combining all results into a list -}
+sequence : List (IO a) -> IO (List a)
+sequence = Core.sequence
 
 {-| Operator version of seq -}
 (>>>) : Core.IO a -> Core.IO b -> Core.IO b

--- a/src/Console/Core.elm
+++ b/src/Console/Core.elm
@@ -47,6 +47,13 @@ map f io = case io of
   Pure   a   -> Pure (f a)
   Impure iof -> Impure (mapF (map f) iof)
 
+{-| Apply a pure function to two IO values -}
+map2 : (a -> b -> result) -> IO a -> IO b -> IO result
+map2 f a b =
+  a `andThen` \x ->
+  b `andThen` \y ->
+    pure (f x y)
+
 {-| Alternative interface to forEach  -}
 mapIO : (a -> IO ()) -> List a -> IO ()
 mapIO f xs = List.foldr (seq << f) (pure ()) xs
@@ -82,6 +89,13 @@ andThen io f = case io of
 {-| Run one computation and then another, ignoring the first's output -}
 seq : IO a -> IO b -> IO b
 seq x y = x >>= \_ -> y
+
+{-| Run several computations in a sequence, combining all results into a list -}
+sequence : List (IO a) -> IO (List a)
+sequence ios =
+  case ios of
+    [] -> pure []
+    first :: rest -> map2 (::) first (sequence rest)
 
 {-| Operator version of seq -}
 (>>>) : IO a -> IO b -> IO b


### PR DESCRIPTION
This adds `sequence` for running a list of `IO` values. As a consequence, I've also added `map2`, as it's used in the implementation of `sequence`, and could be a useful function by itself.

I see that there's already `seq`, which could be confusing alongside `sequence` – perhaps it's a good idea to think about a new name for either. I've chosen `sequence` as it's the name of a similar function for `Task`.
